### PR TITLE
Fix OUT_OF_DEVICE_MEMORY on window resize

### DIFF
--- a/base/VulkanExampleBase.cpp
+++ b/base/VulkanExampleBase.cpp
@@ -1740,6 +1740,12 @@ void VulkanExampleBase::windowResize()
 	width = destWidth;
 	height = destHeight;
 	setupSwapChain();
+	vkDestroyImageView(device, multisampleTarget.color.view, nullptr);
+	vkDestroyImage(device, multisampleTarget.color.image, nullptr);
+	vkFreeMemory(device, multisampleTarget.color.memory, nullptr);
+	vkDestroyImageView(device, multisampleTarget.depth.view, nullptr);
+	vkDestroyImage(device, multisampleTarget.depth.image, nullptr);
+	vkFreeMemory(device, multisampleTarget.depth.memory, nullptr);
 	vkDestroyImageView(device, depthStencil.view, nullptr);
 	vkDestroyImage(device, depthStencil.image, nullptr);
 	vkFreeMemory(device, depthStencil.mem, nullptr);


### PR DESCRIPTION
Dragging the window edge on Linux causes dozens of `XCB_CONFIGURE_NOTIFY` events which quickly causes a `VK_ERROR_OUT_OF_DEVICE_MEMORY` in one of the calls to `vkAllocateMemory` in `VulkanExampleBase::setupFrameBuffer()`.

This adds a small change to clean up the allocated memory for the `multisampleTarget` images.