### PR TITLE
Fix jointByteStride for uint16 bufferJoints

### DIFF
--- a/base/VulkanglTFModel.hpp
+++ b/base/VulkanglTFModel.hpp
@@ -758,7 +758,7 @@ namespace vkglTF
 							const tinygltf::Accessor &jointAccessor = model.accessors[primitive.attributes.find("JOINTS_0")->second];
 							const tinygltf::BufferView &jointView = model.bufferViews[jointAccessor.bufferView];
 							bufferJoints = reinterpret_cast<const uint16_t *>(&(model.buffers[jointView.buffer].data[jointAccessor.byteOffset + jointView.byteOffset]));
-							jointByteStride = jointAccessor.ByteStride(jointView) ? (jointAccessor.ByteStride(jointView) / sizeof(float)) : tinygltf::GetTypeSizeInBytes(TINYGLTF_TYPE_VEC4);
+							jointByteStride = jointAccessor.ByteStride(jointView) ? (jointAccessor.ByteStride(jointView) / sizeof(bufferJoints[0])) : tinygltf::GetTypeSizeInBytes(TINYGLTF_TYPE_VEC4);
 						}
 
 						if (primitive.attributes.find("WEIGHTS_0") != primitive.attributes.end()) {


### PR DESCRIPTION
Animated models displayed incorrectly because jointByteStride was not correct, /sizeof(float) was wrong because bufferJoints array is `uint16_t`, not `float`   (`sizeof(uint16_t)` is 2;  `sizeof(float)` is 4)