### PR TITLE
add google() to allprojects.repositories 

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -15,6 +15,7 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         jcenter()
     }
 }


### PR DESCRIPTION
otherwise gradle could not fnd and install aapt2 starting from Android Studio 3.2(gradle 3.2)

```
Execution failed for task ':app:mergeDebugResources'.
> Could not resolve all files for configuration ':app:_internal_aapt2_binary'.
   > Could not find com.android.tools.build:aapt2:3.5.3-5435860.
     Searched in the following locations:
       - https://jcenter.bintray.com/com/android/tools/build/aapt2/3.5.3-5435860/aapt2-3.5.3-5435860.pom
       - https://jcenter.bintray.com/com/android/tools/build/aapt2/3.5.3-5435860/aapt2-3.5.3-5435860-windows.jar
     Required by:
         project :app
```

https://stackoverflow.com/questions/50279792/could-not-find-com-android-tools-buildaapt23-2-0