### PR TITLE
Support MOUSE input for Android target. 

### DIFF
--- a/base/VulkanExampleBase.cpp
+++ b/base/VulkanExampleBase.cpp
@@ -933,6 +933,9 @@ int32_t VulkanExampleBase::handleAppInput(struct android_app* app, AInputEvent* 
 				break;
 			}
 
+			// FIXME: Reusing code for TOUCHSCREEN seemingly works well for MOUSE event source,
+			// but it would be better to provide a dedicated event handling logic for MOUSE event source.
+			case AINPUT_SOURCE_MOUSE:
 			case AINPUT_SOURCE_TOUCHSCREEN: {
 				int32_t action = AMotionEvent_getAction(event);
 				int32_t pointerCount = AMotionEvent_getPointerCount(event);


### PR DESCRIPTION
It is useful to add mouse support on Android Fablet or Tablet for selecting imgui UI widgets.
