### PR TITLE
Check if animations is empty or not.

### DIFF
--- a/base/VulkanglTFModel.hpp
+++ b/base/VulkanglTFModel.hpp
@@ -1337,6 +1337,10 @@ namespace vkglTF
 
 		void updateAnimation(uint32_t index, float time) 
 		{
+			if (animations.empty()) {
+				std::cout << ".glTF does not contain animation." << std::endl;
+				return;
+			}
 			if (index > static_cast<uint32_t>(animations.size()) - 1) {
 				std::cout << "No animation with index " << index << std::endl;
 				return;


### PR DESCRIPTION
When we call `updateAnimation()` for glTF model without animation data by some reason, it will crash at `animations[index]` since `static_cast<uint32_t>(animations.size()) - 1)` become 0xffffffff.