### PR TITLE
Display name of the used physical device in ImGui

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1872,11 +1872,12 @@ public:
 		ImGui::NewFrame();
 
 		ImGui::SetNextWindowPos(ImVec2(10, 10));
-		ImGui::SetNextWindowSize(ImVec2(200 * scale, (models.scene.animations.size() > 0 ? 500 : 420) * scale), ImGuiSetCond_Always);
+		ImGui::SetNextWindowSize(ImVec2(200 * scale, (models.scene.animations.size() > 0 ? 500 : 440) * scale), ImGuiSetCond_Always);
 		ImGui::Begin("Vulkan glTF 2.0 PBR", nullptr, ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove);
 		ImGui::PushItemWidth(100.0f * scale);
 
 		ui->text("www.saschawillems.de");
+		ui->text(deviceProperties.deviceName);
 		ui->text("%.1d fps (%.2f ms)", lastFPS, (1000.0f / lastFPS));
 
 		if (ui->header("Scene")) {


### PR DESCRIPTION
Small but useful code change.

I get this, depending on the `--gpu` command line argument:

![grafik](https://github.com/user-attachments/assets/a578d70e-fff9-43d5-b141-49d1f76c43a3)

Note that my RX 7900 XTX is currently in my smallest PCIE slot, which could explain the lower performance.
